### PR TITLE
Fix android forget password

### DIFF
--- a/Code/Mobile_Android/.idea/deploymentTargetSelector.xml
+++ b/Code/Mobile_Android/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-17T05:45:35.282825144Z">
+        <DropdownSelection timestamp="2025-06-20T14:03:19.180211602Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/home/rdenni/.android/avd/Medium_Phone.avd" />

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/components/OpenBrowser.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/components/OpenBrowser.kt
@@ -8,13 +8,15 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.sp
+import fr.keyz.R
 
 @Composable
 fun OpenBrowserAnnotatedString(url: String, title: String) {
     val context = LocalContext.current
-
+    val noBrowserFound = stringResource(R.string.no_browser_found)
     Text(
         AnnotatedString(
             title
@@ -30,7 +32,7 @@ fun OpenBrowserAnnotatedString(url: String, title: String) {
             try {
                 context.startActivity(browserIntent)
             } catch (e: Exception) {
-                Toast.makeText(context, "No browser found to open the link", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, noBrowserFound, Toast.LENGTH_SHORT).show()
             }
        },
     )

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/components/OpenBrowser.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/components/OpenBrowser.kt
@@ -1,0 +1,37 @@
+package fr.keyz.components
+
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun OpenBrowserAnnotedString(url: String, title: String) {
+    val context = LocalContext.current
+
+    Text(
+        AnnotatedString(
+            title
+        ),
+        fontSize = 12.sp,
+        color = MaterialTheme.colorScheme.secondary,
+        modifier =
+        Modifier.clickable {
+            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                addCategory(Intent.CATEGORY_BROWSABLE)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            try {
+                context.startActivity(browserIntent)
+            } catch (e: Exception) {
+                Toast.makeText(context, "No browser found to open the link", Toast.LENGTH_SHORT).show()
+            }
+       },
+    )
+}

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/components/OpenBrowser.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/components/OpenBrowser.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun OpenBrowserAnnotedString(url: String, title: String) {
+fun OpenBrowserAnnotatedString(url: String, title: String) {
     val context = LocalContext.current
 
     Text(

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/login/LoginScreen.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/login/LoginScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -36,6 +38,8 @@ import fr.keyz.components.CheckBoxWithLabel
 import fr.keyz.components.ErrorAlert
 import fr.keyz.components.Header
 import fr.keyz.components.LoadingDialog
+import fr.keyz.components.OpenBrowserAnnotedString
+import fr.keyz.components.OpenBrowserButton
 import fr.keyz.components.TopText
 import fr.keyz.ui.components.OutlinedTextField
 import fr.keyz.ui.components.PasswordInput
@@ -111,15 +115,7 @@ fun LoginScreen(
                         viewModel.updateEmailAndPassword(null, null, value)
                     },
                 )
-                Text(
-                    AnnotatedString(
-                        stringResource(R.string.forgot_password),
-                    ),
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.secondary,
-                    modifier =
-                    Modifier.clickable { navController.navigate("forgotPassword") },
-                )
+                OpenBrowserAnnotedString("https://dev.space.keyz-app.fr/forgot-password", stringResource(R.string.forgot_password))
             }
             Button(
                 onClick = { viewModel.login({ isOwner.value = it }) },

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/login/LoginScreen.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/login/LoginScreen.kt
@@ -35,7 +35,7 @@ import fr.keyz.components.CheckBoxWithLabel
 import fr.keyz.components.ErrorAlert
 import fr.keyz.components.Header
 import fr.keyz.components.LoadingDialog
-import fr.keyz.components.OpenBrowserAnnotedString
+import fr.keyz.components.OpenBrowserAnnotatedString
 import fr.keyz.components.TopText
 import fr.keyz.ui.components.OutlinedTextField
 import fr.keyz.ui.components.PasswordInput
@@ -111,7 +111,7 @@ fun LoginScreen(
                         viewModel.updateEmailAndPassword(null, null, value)
                     },
                 )
-                OpenBrowserAnnotedString("https://dev.space.keyz-app.fr/forgot-password", stringResource(R.string.forgot_password))
+                OpenBrowserAnnotatedString("https://dev.space.keyz-app.fr/forgot-password", stringResource(R.string.forgot_password))
             }
             Button(
                 onClick = { viewModel.login({ isOwner.value = it }) },

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/login/LoginScreen.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/login/LoginScreen.kt
@@ -19,13 +19,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,7 +36,6 @@ import fr.keyz.components.ErrorAlert
 import fr.keyz.components.Header
 import fr.keyz.components.LoadingDialog
 import fr.keyz.components.OpenBrowserAnnotedString
-import fr.keyz.components.OpenBrowserButton
 import fr.keyz.components.TopText
 import fr.keyz.ui.components.OutlinedTextField
 import fr.keyz.ui.components.PasswordInput

--- a/Code/Mobile_Android/app/src/main/java/fr/keyz/realProperty/details/RealPropertyDetailsViewModel.kt
+++ b/Code/Mobile_Android/app/src/main/java/fr/keyz/realProperty/details/RealPropertyDetailsViewModel.kt
@@ -44,7 +44,6 @@ class RealPropertyDetailsViewModel(
     private var _property = MutableStateFlow(DetailedProperty())
     private val _apiError = MutableStateFlow(ApiErrors.NONE)
     private val _isLoading = MutableStateFlow(false)
-    private val _isLoadingMutex = Mutex()
 
     val property: StateFlow<DetailedProperty> = _property.asStateFlow()
     val documents = mutableStateListOf<Document>()
@@ -53,11 +52,7 @@ class RealPropertyDetailsViewModel(
     val isLoading = _isLoading.asStateFlow()
 
     fun setIsLoading(value : Boolean) {
-        viewModelScope.launch {
-            _isLoadingMutex.lock()
-            _isLoading.value = value
-            _isLoadingMutex.unlock()
-        }
+        _isLoading.value = value
     }
 
     fun loadProperty(newProperty: DetailedProperty) {

--- a/Code/Mobile_Android/app/src/main/res/values-fr/strings.xml
+++ b/Code/Mobile_Android/app/src/main/res/values-fr/strings.xml
@@ -218,5 +218,6 @@
     <string name="available_properties">Propriété(s) disponible(s)</string>
     <string name="reminders">Rappels</string>
     <string name="damages_list">Liste des dommages</string>
+    <string name="no_browser_found">Aucun navigateur trouvé</string>
 
 </resources>

--- a/Code/Mobile_Android/app/src/main/res/values/strings.xml
+++ b/Code/Mobile_Android/app/src/main/res/values/strings.xml
@@ -217,4 +217,5 @@
     <string name="available_properties">Available properties</string>
     <string name="reminders">Reminders</string>
     <string name="damages_list">Damage List</string>
+    <string name="no_browser_found">No browser found to open the link</string>
 </resources>


### PR DESCRIPTION
* Create a new button that open a browser with a certain link
* Use this button to reach the forgot password page
* remove the useless mutex on isLoading on the realPropertyDetails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a clickable "forgot password" link on the login screen that opens the reset page in your device's web browser.

- **Bug Fixes**
  - Improved reliability when updating loading states in property details, resulting in smoother user experience.

- **Localization**
  - Added new messages for browser-related notifications in English and French.

- **Chores**
  - Updated internal configuration files without affecting user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->