### PR TITLE
Fix/ios app detailview image size

### DIFF
--- a/Code/Mobile_iOS/Keyz/Sources/Components/ErrorNotificationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Components/ErrorNotificationView.swift
@@ -17,7 +17,9 @@ struct ErrorNotificationView: View {
     let type: NotificationType
     @State private var isVisible = false
     @State private var opacity: Double = 0.0
-    private let duration: Double = 5.0
+    private var duration: Double {
+        type == .success ? 2.0 : 5.0
+    }
 
     init(message: String, type: NotificationType = .error) {
         self.message = message

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
@@ -463,28 +463,29 @@ struct PropertyDetailView: View {
     private func imageView(property: Property) -> some View {
         Group {
             if isImageLoading {
-                VStack {
-                    Spacer()
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle())
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity, maxHeight: 200)
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
+                    .frame(maxWidth: .infinity, maxHeight: 200)
             } else if let uiImage = property.photo {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFill()
-                    .frame(height: 200)
+                    .frame(maxHeight: 200)
                     .clipped()
+                    .accessibilityLabel("image_property")
             } else {
                 Image("DefaultImageProperty")
                     .resizable()
                     .scaledToFill()
-                    .frame(height: 200)
+                    .frame(maxHeight: 200)
                     .clipped()
                     .accessibilityLabel("image_property")
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: 200)
+        .ignoresSafeArea(.all, edges: .horizontal)
+        .clipped()
+        .frame(maxWidth: UIScreen.main.bounds.width)
     }
 
     private var backButtonView: some View {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
@@ -79,7 +79,6 @@ class OwnerPropertyViewModel: ObservableObject {
         }
         
         let body: [String: Any] = ["data": imageString]
-        
         let url = URL(string: "\(APIConfig.baseURL)/owner/properties/\(propertyID)/picture/")!
         
         var urlRequest = URLRequest(url: url)
@@ -90,7 +89,7 @@ class OwnerPropertyViewModel: ObservableObject {
         
         let jsonData = try JSONSerialization.data(withJSONObject: body)
         urlRequest.httpBody = jsonData
-        
+                
         let (data, response) = try await URLSession.shared.data(for: urlRequest)
         
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -868,7 +867,8 @@ class OwnerPropertyViewModel: ObservableObject {
             guard let imageData = image.jpegData(compressionQuality: 0.8) else {
                 return nil
             }
-            return imageData.base64EncodedString()
+            let base64String = "data:image/jpeg;base64,\(imageData.base64EncodedString())"
+            return base64String
         }.value
     }
 }


### PR DESCRIPTION
Issue: 
- Oversized images in PropertyDetailView were stretching the view beyond screen bounds.

Resolution:
- Updated imageView to use .frame(maxWidth: UIScreen.main.bounds.width, maxHeight: 200) and .clipped() to ensure edge-to-edge display without layout overflow.

Other changes :
- Reduced success alert duration before dismiss
- Fixed bad image formatting in creation of a new property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification banners now display for a shorter duration (2 seconds) when indicating success, and for 5 seconds for other types, improving feedback responsiveness.

* **Accessibility**
  * Added accessibility labels to property images, enhancing support for assistive technologies.

* **Style**
  * Improved the layout and sizing of property images for a more consistent and visually appealing presentation.

* **Bug Fixes**
  * Adjusted the format of uploaded property images to include the correct data URI scheme, ensuring better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->